### PR TITLE
Linuslyt/graph select

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -36,7 +36,7 @@ function App() {
         getMrDMD();
       })
       .catch((err) => console.error("Error fetching data:", err));
-  }, []);
+  }, []); // TODO: dependency on [selectedDims]
 
   const getNodeData = async (selectedCols) => {
     try {

--- a/ui/src/components/DRView.js
+++ b/ui/src/components/DRView.js
@@ -120,7 +120,8 @@ const DR = ({ data, fcs, type, setSelectedPoints, selectedPoints, hoveredPoint, 
                     }
             })
             .on("mouseover", function (event, d) {
-                setHoveredPoint(getIdVal(d));
+                // This causes every single component that takes hoveredPoint as a prop to rerender.
+                // setHoveredPoint(getIdVal(d));
                 d3.select(this)
                     .transition()
                     .duration(150)
@@ -135,7 +136,8 @@ const DR = ({ data, fcs, type, setSelectedPoints, selectedPoints, hoveredPoint, 
                 });
             })
             .on("mouseout", function (event, d) {
-                setHoveredPoint(null);
+                // This causes every single component that takes hoveredPoint as a prop to rerender.
+                // setHoveredPoint(null);
                 d3.select(this)
                     .transition()
                     .duration(150)

--- a/ui/src/components/FeatureView.js
+++ b/ui/src/components/FeatureView.js
@@ -1,7 +1,5 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { getColor } from '../utils/colors.js';
-import { Card, List, Checkbox, Row, Col } from "antd";
-import * as d3 from 'd3';
+import { Card, Checkbox, Col, List, Row } from "antd";
+import React from 'react';
 import LineChart from './LineChart.js';
 
 const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, hoveredPoint, setHoveredPoint }) => {
@@ -44,17 +42,24 @@ const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, hove
                 />
             </Col>
             <Col span={18}>
-                {dims.map((field, index) => (
-                    <LineChart 
-                        key={`chart-${index}`}
-                        data={data.data} 
-                        field={field} 
-                        index={index} 
-                        selectedPoints={selectedPoints}
-                        hoveredPoint={hoveredPoint}
-                        setHoveredPoint={setHoveredPoint}
-                    />
-                ))}
+                {dims.map((field, index) => {
+                    const filteredData = data.data.map(d => ({
+                        timestamp: new Date(d.timestamp),
+                        nodeId: d.nodeId,
+                        value: d[field]
+                    }));
+                    return (
+                        <LineChart 
+                            key={`chart-${index}`}
+                            data={filteredData} 
+                            field={field} 
+                            index={index} 
+                            selectedPoints={selectedPoints}
+                            hoveredPoint={hoveredPoint}
+                            setHoveredPoint={setHoveredPoint}
+                        />
+                    )
+                })}
             </Col>
         </Row>
       </Card>

--- a/ui/src/components/FeatureView.js
+++ b/ui/src/components/FeatureView.js
@@ -1,10 +1,11 @@
 import { Card, Checkbox, Col, List, Row } from "antd";
-import React from 'react';
+import React, { useState } from 'react';
 import LineChart from './LineChart.js';
 
 const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, hoveredPoint, setHoveredPoint }) => {
     const dims = selectedDims.filter(field => data.data && data.data.length > 0 && field in data.data[0]);
     const features = data.features;
+    const [selectedTimeRange, setSelectedTimeRange] = useState(['2024-02-21 16:07:30Z', '2024-02-21 17:41:45Z'])
 
   const handleCheckboxChange = (key) => {
     setSelectedDims(prevSelectedDims => {
@@ -14,7 +15,16 @@ const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, hove
             return [...prevSelectedDims, key];
         }
     });
-}
+  }
+
+    const handleUpdateEvent = (event) => {
+        setSelectedTimeRange(event.detail);
+        // setSelectedTimeRange(event.detail);
+        // const { detail: newDomain } = event;
+        // updateChart(newDomain);
+    };
+
+    window.addEventListener(`batch-update-charts`, handleUpdateEvent);
 
   return (
       <Card title="FEATURE VIEW" size="small" style={{ height: "auto", maxHeight: '530px', overflow:'auto' }}> 
@@ -43,11 +53,15 @@ const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, hove
             </Col>
             <Col span={18}>
                 {dims.map((field, index) => {
+                    const selectedNodes = new Set(selectedPoints);
+                    const start = new Date(selectedTimeRange[0]);
+                    const end = new Date(selectedTimeRange[1]);
                     const filteredData = data.data.map(d => ({
                         timestamp: new Date(d.timestamp),
                         nodeId: d.nodeId,
                         value: d[field]
-                    }));
+                    })).filter(d => selectedNodes.has(d.nodeId) && d.timestamp >= start && d.timestamp <= end);
+                    
                     return (
                         <LineChart 
                             key={`chart-${index}`}

--- a/ui/src/components/LineChart.js
+++ b/ui/src/components/LineChart.js
@@ -6,11 +6,7 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
     const svgContainerRef = useRef();
     const [size, setSize] = useState({ width: 800, height: 300 });
     const [chartId, setChartId] = useState(index);
-    const chartdata = data.map(d => ({
-        timestamp: new Date(d.timestamp),
-        nodeId: d.nodeId,
-        value: d[field]
-    }));
+    const chartdata = data;
     const [selectedTimeRange, setSelectedTimeRange] = useState(['2024-02-21 16:07:30Z', '2024-02-21 17:41:45Z'])
     // const [isLocalHover, setIsLocalHover] = useState(false);
     const [tooltip, setTooltip] = useState({

--- a/ui/src/components/LineChart.js
+++ b/ui/src/components/LineChart.js
@@ -7,7 +7,6 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
     const [size, setSize] = useState({ width: 800, height: 300 });
     const [chartId, setChartId] = useState(index);
     const chartdata = data;
-    const [selectedTimeRange, setSelectedTimeRange] = useState(['2024-02-21 16:07:30Z', '2024-02-21 17:41:45Z'])
     // const [isLocalHover, setIsLocalHover] = useState(false);
     const [tooltip, setTooltip] = useState({
             visible: false,
@@ -16,7 +15,6 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
             y: 0
         });
 
-    const selectedNodes = new Set(selectedPoints);
     useEffect(() => {
       console.log('rerendering');
       if (!svgContainerRef.current || !data) return;
@@ -47,11 +45,7 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
         .attr('class', 'focus')
         .attr('id', `focus-line-${index}`)
 
-      const start = new Date(selectedTimeRange[0]);
-      const end = new Date(selectedTimeRange[1]);
-      const filtered = chartdata.filter(d => {
-        return selectedNodes.has(d.nodeId) && d.timestamp >= start && d.timestamp <= end
-      });
+      const filtered = chartdata;
 
       const groupedData = d3.group(filtered, d => d.nodeId);
 
@@ -184,7 +178,7 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
       focus.node().xScale = xScale;
       focus.node().yScale = yScale;
       
-      }, [data, field, index, selectedPoints, selectedTimeRange]);
+      }, [data, field, index, selectedPoints]);
 
       // const updateChart = (newDomain) => {
       //   const chart = d3.select(`#focus-line-${chartId}`);
@@ -226,20 +220,7 @@ const LineChart = ({ data, field, index, selectedPoints, setHoveredPoint }) => {
       //         .x(d => xScale(d.timestamp))
       //         .y(d => yScale(d.value))
       //     )
-      // };
-
-
-      // This handler needs to be in a higher context so that there's no duplicated state between
-      // instances of lineChart.
-      const handleUpdateEvent = (event) => {
-        setSelectedTimeRange(event.detail);
-        // setSelectedTimeRange(event.detail);
-        // const { detail: newDomain } = event;
-        // updateChart(newDomain);
-      };
-
-      window.addEventListener(`batch-update-charts`, handleUpdateEvent);
-    
+      // };    
       return <div ref={svgContainerRef} style={{ width: 'auto', height: '190px' }}></div>;
 
 };


### PR DESCRIPTION
- Line chart now only plots data for selected nodes and selected time range
  - Link DR view lasso selection to line chart
  - Link timeline brush selection to line chart
- Refactored line chart data filtering (by feature, nodeId, and time range) logic into parent FeatureView component. This greatly reduces the amount of data sent to each FeatureView instance, preventing out of memory crashes.
- Disabled node mouseover events for DRView during lasso selection. This was causing page crashes, since every mouseover on a node triggers a `setTooltip()` state change, which causes DRView to rerender and conflict with the ongoing lasso event.
- Disabled setHoveredPoint events for both DRView and LineChart. Due to the way the state is defined and passed to components,  _**any update to hoveredPoint causes nearly every component to rerender.**_
  - Particularly for LineChart, due to the amount of lines in close proximity/overlap, simply moving the mouse over the line graphs would cause dozens of hoveredPoint updates. Each update would cause every component w/ `hoveredPoints` as a prop to rerender; at a high enough frequency, these rerenders would crash the page.