### PR TITLE
Plot individual feature contributions; fix timeline time ranges

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -172,6 +172,7 @@ function App() {
                     selectedDims={selectedDims}
                     selectedPoints={selectedPoints}
                     setSelectedDims={setSelectedDims}
+                    fcs={FCs}
                   />
               )}
             </Col>
@@ -184,7 +185,6 @@ function App() {
                   <div>
                       <DR 
                         data={DRTData} 
-                        fcs={FCs}
                         type="time" 
                         setSelectedPoints={setSelectedPoints} 
                         selectedPoints={selectedPoints} 

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -159,7 +159,8 @@ function App() {
                     mgrData={mgrData}
                     bStart={bStart}
                     bEnd={bEnd}
-                    nodeDataStart={nodeData?.data[0]?.timestamp}
+                    nodeDataStart={new Date(nodeData?.data[0]?.timestamp)}
+                    nodeDataEnd={new Date(nodeData?.data[nodeData?.data.length - 1]?.timestamp)}
                   />
                   )}
                 {(!nodeData) ? (

--- a/ui/src/components/AreaChart.js
+++ b/ui/src/components/AreaChart.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { getColor } from '../utils/colors.js';
 import * as d3 from 'd3';
+import React, { useEffect, useRef, useState } from 'react';
+import { getColor } from '../utils/colors.js';
 
 const AreaChart = ({ data, field, index, chartType }) => {
     const svgContainerRef = useRef();

--- a/ui/src/components/DRView.js
+++ b/ui/src/components/DRView.js
@@ -315,13 +315,6 @@ const DR = ({ data, fcs, type, setSelectedPoints, selectedPoints }) => {
                         </Form>
                     </div>
                 </Col>
-
-                {/* <Col span={10} style={{ borderLeft: '1px solid #d9d9d9' }}>
-                    <Contributions
-                        data={data}
-                        FCs={fcs} 
-                    /> 
-                </Col> */}
             </Row>
         </Card>
         <Tooltip

--- a/ui/src/components/DRView.js
+++ b/ui/src/components/DRView.js
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from 'react';
 import { colorScale, getColor } from '../utils/colors.js';
 import LassoSelection from '../utils/lasso.js';
 import Tooltip from '../utils/tooltip.js';
-import Contributions from './Contributions.js';
 
 const { Option } = Select;
 
@@ -283,7 +282,7 @@ const DR = ({ data, fcs, type, setSelectedPoints, selectedPoints }) => {
             style={{ height:'auto' }}
         >
             <Row>
-                <Col span={14}>
+                <Col span={24}>
                     <div ref={svgContainerRef}></div>
 
                     <LassoSelection svgRef={svgContainerRef} targetItems={".dr-circle"} onSelect={handleSelection} />
@@ -317,12 +316,12 @@ const DR = ({ data, fcs, type, setSelectedPoints, selectedPoints }) => {
                     </div>
                 </Col>
 
-                <Col span={10} style={{ borderLeft: '1px solid #d9d9d9' }}>
+                {/* <Col span={10} style={{ borderLeft: '1px solid #d9d9d9' }}>
                     <Contributions
                         data={data}
                         FCs={fcs} 
                     /> 
-                </Col>
+                </Col> */}
             </Row>
         </Card>
         <Tooltip

--- a/ui/src/components/FeatureContributionBarGraph.js
+++ b/ui/src/components/FeatureContributionBarGraph.js
@@ -1,0 +1,115 @@
+import * as d3 from 'd3';
+import React, { useEffect, useRef, useState } from 'react';
+import { colorScale } from '../utils/colors.js';
+
+export default function FeatureContributionBarGraph({ feature, fcData, graphId }) {
+    const featureSvgRef = useRef();
+    const [size, ] = useState({ width: 400, height: 400 });
+    const AXIS_TICK_FONT_SIZE = 50;
+    useEffect(() => {
+        if (!featureSvgRef.current || !fcData ) return;
+        // console.log(feature, graphId, fcData);
+        const margin = { top: 20, right: 0, bottom: 20, left: 0 };
+        const xDomain = [-1, 1];
+        const xScale = d3.scaleLinear()
+            .domain(xDomain)
+            .range([margin.left, size.width - margin.right]);
+        const y = d3.scaleBand()
+            .domain(fcData.map(d => d.cluster))
+            .range([margin.top, size.height - margin.bottom])
+            .paddingInner(0.2);
+
+        const svg = d3.select(featureSvgRef.current)
+            .append("svg")
+            .attr('id', `matrix-svg`)
+            .attr("width", "100%")
+            .attr("height", "100%")
+            .attr("viewBox", `0 0 ${size.width} ${size.height}`)
+            .attr("preserveAspectRatio", "xMidYMid meet");
+        
+        /* Uncomment and adjust margin.top to display x axis */
+        // svg.append('g')
+        //     .attr('transform', `translate(0, ${margin.top})`)
+        //     .call(d3.axisTop(xScale).tickValues([-1, -0.5, 0, 0.5, 1]))
+        //     .selectAll('text')
+        //     .style("font-size", `${AXIS_TICK_FONT_SIZE}px`)
+        //     .style("vertical-align", "middle");
+
+        // Plot bars
+        svg.append('g')
+        .selectAll()
+        .data(fcData)
+        .join('rect')
+            .attr('x', d => d.value >= 0 ? xScale(0) : xScale(d.value))
+            .attr('y', (d,i) => y(d.cluster))
+            .attr('width', d => Math.abs(xScale(d.value) - xScale(0)))
+            .attr('height', (d,i) => y.bandwidth())
+            .attr('fill', d => colorScale(d.cluster))
+            .attr('opacity', 0.85)
+            .append('title').text((d,i) => `Contribution to cluster ${d.cluster}: ${d.value.toFixed(4)}`)
+
+        /* Uncomment below for */
+        // // Cluster labels on left
+        // const clusterLabels = svg.append('g')
+        //     .attr('transform', `translate(0, 0)`)
+        //     .call(d3.axisRight(y).tickSizeOuter(0).tickSizeInner(0).tickPadding(20));
+        // clusterLabels.select(".domain") // Select the domain line
+        //     .remove();
+        // clusterLabels.selectAll('text')
+        //     .style("font-size", `${AXIS_TICK_FONT_SIZE}px`)
+        //     .style("font-weight", "bold")
+        //     .style("vertical-align", "middle");
+        
+        // // Axis in middle
+        // svg.append('g')
+        //     .attr('transform', `translate(${(size.width - margin.left - margin.right) / 2 + margin.left}, 0)`)
+        //     .call(d3.axisRight(y).tickSizeOuter(0).tickValues([]))
+        //     .selectAll('text')
+        //     .style("font-size", `${AXIS_TICK_FONT_SIZE}px`)
+        //     .style("font-weight", "bold")
+        //     .style("vertical-align", "middle");
+        
+        // Plot cluster y axis
+        svg.append('g')
+            .attr('transform', `translate(${(size.width - margin.left - margin.right) / 2 + margin.left}, 0)`)
+            .call(d3.axisRight(y).tickSizeOuter(0).tickSizeInner(0).tickPadding(20).tickFormat(d => `c${d}`))
+            .selectAll('text')
+            .style("font-size", `${AXIS_TICK_FONT_SIZE}px`)
+            .style("font-weight", "bold")
+            .style("vertical-align", "middle");
+
+        // Add drop shadow to labels for visibility
+        const defs = svg.append("defs");
+
+        const filter = defs.append("filter")
+            .attr("id", "white-shadow")
+            .attr("x", "-50%")
+            .attr("y", "-50%")
+            .attr("width", "150%")
+            .attr("height", "150%");
+
+        filter.append("feDropShadow")
+            .attr("dx", 0)
+            .attr("dy", 0)
+            .attr("stdDeviation", 4)
+            .attr("flood-color", "white")
+            .attr("flood-opacity", 0.75);
+
+        svg.selectAll(".tick text")
+            .attr("filter", "url(#white-shadow)")
+            .style("fill", "black");
+
+        svg.selectAll(".tick text")
+            .attr("filter", "url(#white-shadow)")
+            .style("fill", "black");
+        
+        svg.selectAll(".cluster-title")
+            .attr("filter", "url(#white-shadow)")
+            .style("fill", "black");
+      }, [fcData]);
+    
+      return (
+        <svg id={graphId} ref={featureSvgRef} style={{width: '100%', height: 100}}></svg>
+        );
+
+};

--- a/ui/src/components/FeatureSelect.js
+++ b/ui/src/components/FeatureSelect.js
@@ -1,0 +1,63 @@
+import { Checkbox, List } from "antd";
+import React from 'react';
+
+export default function FeatureSelect({ data, processed, selectedDims, selectedPoints, setSelectedDims, featureData, setFeatureData }) {
+  const handleCheckboxChange = (key) => {
+    const existingColumns = Object.keys(featureData);
+    if (!existingColumns.includes(key)) {
+        fetch(`http://127.0.0.1:5010/nodeData/${key}`)
+            .then(response => response.json())
+            .then(newData => {
+                if (newData.data.length === featureData[Object.keys(featureData)[0]].length) {
+                    const processedColumn = newData.data.map(row => ({
+                        value: row[key],  
+                        timestamp: new Date(row.timestamp), 
+                        nodeId: row.nodeId
+                    }));    
+                    setFeatureData(featureData => ({
+                        ...featureData,
+                        [key]: processedColumn  // new column
+                    }));
+                } else {
+                    console.error(`Data length mismatch: expected ${processed[Object.keys(processed)[0]].length}, got ${newData.data.length}`);
+                }
+            })
+            .catch(error => console.error('Error fetching data:', error));
+    }
+    setSelectedDims(prevSelectedDims => {
+        if (prevSelectedDims.includes(key)) {
+            return prevSelectedDims.filter(dim => dim !== key);
+        } else {
+            return [...prevSelectedDims, key];
+        }
+    });
+  }
+  
+  return (
+    <List
+      style={{ width: "100%", maxWidth: 500, overflowY: "scroll", maxHeight: 450, marginRight: "10px" }}
+      bordered
+      dataSource={data.features}
+      renderItem={(key, index) => {
+      return (
+          <List.Item key={key} style={{ display: "flex", alignItems: "center", padding: "5px 10px" }}>
+          
+          <div style={{display: 'flex', flexDirection: 'column'}}>
+              <div style={{display: 'flex'}}>
+                  <Checkbox
+                      checked={selectedDims.includes(key)}
+                      onChange={() => handleCheckboxChange(key)}
+                      style={{ marginRight: "10px" }}
+                  />
+                  <span style={{ flexGrow: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                      {key}
+                  </span>
+              </div>
+              <svg style={{width: '100%', height: 100}}></svg>
+          </div>
+          </List.Item>
+      );
+      }}
+    />
+  )
+}

--- a/ui/src/components/FeatureSelect.js
+++ b/ui/src/components/FeatureSelect.js
@@ -1,8 +1,9 @@
 import { Checkbox, List } from "antd";
 import React from 'react';
+import FeatureContributionBarGraph from "./FeatureContributionBarGraph";
 
-export default function FeatureSelect({ data, processed, selectedDims, selectedPoints, setSelectedDims, featureData, setFeatureData }) {
-  const handleCheckboxChange = (key) => {
+export default function FeatureSelect({ data, processed, selectedPoints, selectedDims, setSelectedDims, featureData, setFeatureData, fcs }) {
+    const handleCheckboxChange = (key) => {
     const existingColumns = Object.keys(featureData);
     if (!existingColumns.includes(key)) {
         fetch(`http://127.0.0.1:5010/nodeData/${key}`)
@@ -32,7 +33,7 @@ export default function FeatureSelect({ data, processed, selectedDims, selectedP
         }
     });
   }
-  
+
   return (
     <List
       style={{ width: "100%", maxWidth: 500, overflowY: "scroll", maxHeight: 450, marginRight: "10px" }}
@@ -45,6 +46,7 @@ export default function FeatureSelect({ data, processed, selectedDims, selectedP
           <div style={{display: 'flex', flexDirection: 'column'}}>
               <div style={{display: 'flex'}}>
                   <Checkbox
+                      // TODO: refactor checkbox state so FeatureContributionBarGraph doesn't rerender on checkbox change
                       checked={selectedDims.includes(key)}
                       onChange={() => handleCheckboxChange(key)}
                       style={{ marginRight: "10px" }}
@@ -53,7 +55,13 @@ export default function FeatureSelect({ data, processed, selectedDims, selectedP
                       {key}
                   </span>
               </div>
-              <svg style={{width: '100%', height: 100}}></svg>
+              <FeatureContributionBarGraph graphId={`${key.replace(/\s/g, "_")}-feat-graph`} feature={key}
+                //TODO: fix issue with less FCs than available data features
+                fcData={!fcs || data.features.indexOf(key) === -1 || data.features.indexOf(key) >= fcs.agg_feat_contrib_mat.length ? []
+                            : fcs.order_col.map(clusterId => ({
+                                cluster: clusterId,
+                                value: fcs.agg_feat_contrib_mat[data.features.indexOf(key)][clusterId]
+                            }))}/>
           </div>
           </List.Item>
       );

--- a/ui/src/components/FeatureView.js
+++ b/ui/src/components/FeatureView.js
@@ -3,7 +3,7 @@ import React, { useMemo, useState } from 'react';
 import FeatureSelect from "./FeatureSelect.js";
 import LineChart from './LineChart.js';
 
-const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims }) => {
+const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims, fcs }) => {
     let processed = {};
     const [featureData, setFeatureData] = useState(processed);
     
@@ -43,10 +43,11 @@ const FeatureView = ({ data, selectedDims, selectedPoints, setSelectedDims }) =>
         <Row gutter={[16, 16]}>
             {/* Left column: List */}
             <Col span={10}>
+                {/* TODO: move this to sidebar at the app level */}
                 <FeatureSelect 
                     data={data} processed={processed} selectedDims={selectedDims}
                     selectedPoints={selectedPoints} setSelectedDims={setSelectedDims}
-                    featureData={featureData} setFeatureData={setFeatureData}/>
+                    featureData={featureData} setFeatureData={setFeatureData} fcs={fcs}/>
             </Col>
             <Col span={14}>
                 {selectedDims.map((field, index) => {

--- a/ui/src/components/LineChart.js
+++ b/ui/src/components/LineChart.js
@@ -4,7 +4,7 @@ import { getColor } from '../utils/colors.js';
 import Tooltip from '../utils/tooltip.js';
 
 const LineChart = ({ data, field, index }) => {
-    console.log(`rendering line chart ${index} for field ${field}`, data);
+    // console.log(`rendering line chart ${index} for field ${field}`, data);
     const svgContainerRef = useRef();
     const [size, setSize] = useState({ width: 700, height: 300 });
     const [chartId, setChartId] = useState(index);
@@ -17,7 +17,6 @@ const LineChart = ({ data, field, index }) => {
     });
 
     useEffect(() => {
-      console.log('rerendering');
       if (!svgContainerRef.current || !data) return;
       const margin = { top: 40, right: 60, bottom: 60, left: 70 };
 

--- a/ui/src/components/LineChart.js
+++ b/ui/src/components/LineChart.js
@@ -1,9 +1,10 @@
 import * as d3 from 'd3';
 import React, { useEffect, useRef, useState } from 'react';
-import Tooltip from '../utils/tooltip.js';
 import { getColor } from '../utils/colors.js';
+import Tooltip from '../utils/tooltip.js';
 
 const LineChart = ({ data, field, index }) => {
+    console.log(`rendering line chart ${index} for field ${field}`, data);
     const svgContainerRef = useRef();
     const [size, setSize] = useState({ width: 700, height: 300 });
     const [chartId, setChartId] = useState(index);


### PR DESCRIPTION
## Changes
- Split feature select sidebar into separate `FeatureSelect` component.
- Plot individual feature contributions per feature under each checkbox item, using a new `FeatureContributionBarGraph` component.
  - Old combined feature contributions graph left untouched in `Contributions.js`.
- Changed TimelineView to base its x scale on the time range of available `nodeData`.
  - All displayed timestamps changed to UTC format.
  - Note: While the x scale is defined using the time range from `nodeData`, it plots the data from `mgrData`. Since the min/max timestamps for `nodeData` and `mgrData` do not line up, the timeline looks mostly empty on the right.
    - Regardless, brushing on the timeline now allows for selecting the full `nodeData` time range for the feature view line graphs.
    - For reference, here are the data min/max time stamps (also logged in dev console):
    ```
    min/max from mgrData (UTC) Wed, 21 Feb 2024 00:05:45 GMT Thu, 22 Feb 2024 00:05:45 GMT
    min/max from nodeData (UTC) Wed, 21 Feb 2024 13:36:00 GMT Thu, 22 Feb 2024 07:59:45 GMT
    time range (UTC) with both node and mgr data available: Wed, 21 Feb 2024 13:36:00 GMT, Thu, 22 Feb 2024 00:05:45 GMT
    ```

## Known issues
- Retrieved FC data array length does not match `data.features` array length, meaning the final feature checkbox item does not have FC data to plot.

<img width="812" alt="image" src="https://github.com/user-attachments/assets/78ffeb64-4cb1-48ec-8137-6a9b6e6390b0" />
