### PR TITLE
Recompute kMeans on num clusters change

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -1,12 +1,13 @@
 import json
 import os
-import pandas as pd
-from flask import Flask, jsonify, request
-from flask_cors import CORS
 from datetime import datetime
-from scripts.dr_time import get_dr_time
-from scripts.dr_time import get_feat_contributions
+
+import pandas as pd
+from flask import Flask, abort, jsonify
+from flask_cors import CORS
 from mrdmd import get_mrdmd, get_mrdmd_with_new_base
+from scripts.dr_time import (get_dr_time, get_feat_contributions,
+                             recompute_clusters)
 
 app = Flask(__name__)
 CORS(app)
@@ -16,6 +17,7 @@ ts_data = pd.DataFrame()
 filepath = './data/farm/'
 CACHE_DIR = './cache'
 NODE_CACHE = './cache/dune_node_data.parquet'
+DR2_CACHE_NAME = './cache/drTimeDataDR2.parquet'
 
 def get_timeseries_data(file='far_data_2024-02-21.csv'):
     # TODO: convert to parquet instead of global
@@ -23,6 +25,11 @@ def get_timeseries_data(file='far_data_2024-02-21.csv'):
     global filepath
     ts_data = pd.read_csv(filepath+file).fillna(0.0)
     return ts_data
+
+def clear_DR2_cache():
+    print('Clearing DR2 cache on startup.')
+    if os.path.exists(DR2_CACHE_NAME):
+        os.remove(DR2_CACHE_NAME)
 
 @app.route('/mgrData', methods=['GET'])
 def get_json_data():
@@ -52,6 +59,17 @@ def get_dr_time_data():
         },
     }
     return jsonify(response)
+
+@app.route('/recomputeClusters/<numClusters>')
+def get_new_cluster_ids(numClusters):
+    recomputed = recompute_clusters(int(numClusters))
+    if recomputed is None:
+        # DR2 is wiped on startup so recompute_clusters always pulls from fresh DR2 data.
+        # recompute_clusters() returns None if DR2 is not found in cache.
+        # This error state can happen if you query /recomputeClusters on server startup before /drTimeData,
+        # e.g. if the server restarted and # clusters is changed on the frontend without a page refresh.
+        abort(404, description="No cached DR2 was found.")
+    return jsonify(recomputed)
 
 @app.route('/mrdmd/<nodes>/<selectedCols>/<recompute_base>/<new_base>/<bmin>/<bmax>/<sob>/<eob>', methods=['GET'])
 def get_mrdmd_results(nodes, selectedCols, recompute_base=0, new_base=0, bmin=None, bmax=None, sob=None, eob=None):
@@ -138,4 +156,5 @@ def list_json_files():
 
 if __name__ == '__main__':
     ts_data = get_timeseries_data()
+    clear_DR2_cache()
     app.run(debug=True, port=5010)

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -37,8 +37,7 @@ function App() {
   }, []); // TODO: dependency on [selectedDims]
 
   const updateClustersCallback = useCallback(async (numClusters) => {
-    console.log(`updating clusters with k=${numClusters}`)
-    // TODO: get new cluster ids, rerun set node cluster map
+    console.log(`Recomputing clusters with numClusters=${numClusters}`)
     try {
       const response = await fetch(`http://127.0.0.1:5010/recomputeClusters/${numClusters}`);
       if (response.ok) {

--- a/ui/src/components/DRPlot.js
+++ b/ui/src/components/DRPlot.js
@@ -77,7 +77,7 @@ const DR = ({ data, type, setSelectedPoints, selectedPoints, selectedDims, zScor
             .attr('stroke','black')
             .attr('stroke-width', '1px')
             .attr("r", 4)
-            .style('fill', d => colorScale(nodeClusterMap.get(d.nodeId))) // TODO: hoist this into separate useeffect just for nodeclustermap
+            .style('fill', d => colorScale(nodeClusterMap.get(d.nodeId)))
             .style("opacity", d => {
                 return selectedPoints.includes(d.nodeId) ? highlight : nonHighlight;
             })
@@ -288,7 +288,7 @@ const DR = ({ data, type, setSelectedPoints, selectedPoints, selectedDims, zScor
                                 <Select
                                 style={{ width: 60 }}
                                 onChange={(value) => {
-                                    handleSubmitNKMeans({ numClusters: value }); // manually call submit when changed
+                                    handleSubmitNKMeans({ numClusters: value });
                                 }}
                                 >
                                     {clusterOptions.map((num) => (

--- a/ui/src/components/FeatureContributionBarGraph.js
+++ b/ui/src/components/FeatureContributionBarGraph.js
@@ -8,6 +8,9 @@ export default function FeatureContributionBarGraph({ feature, fcData, graphId }
     const AXIS_TICK_FONT_SIZE = 50;
     useEffect(() => {
         if (!featureSvgRef.current || !fcData ) return;
+        // Clear graph for updates due to fcData (cluster ID) changes
+        d3.select(featureSvgRef.current).selectAll('*').remove()
+
         // console.log(feature, graphId, fcData);
         const margin = { top: 20, right: 0, bottom: 20, left: 0 };
         const xDomain = [-1, 1];

--- a/ui/src/components/FeatureSelect.js
+++ b/ui/src/components/FeatureSelect.js
@@ -112,7 +112,6 @@ export default function FeatureSelect({ data, processed, selectedPoints, selecte
                   </span>
               </div>
               <FeatureContributionBarGraph graphId={`${key.replace(/\s/g, "_")}-feat-graph`} feature={key}
-                //TODO: fix issue with less FCs than available data features
                 fcData={!fcs || data.features.indexOf(key) === -1 || data.features.indexOf(key) >= fcs.agg_feat_contrib_mat.length ? []
                             : fcs.order_col.map(clusterId => ({
                                 cluster: clusterId,

--- a/ui/src/components/FeatureView.js
+++ b/ui/src/components/FeatureView.js
@@ -1,12 +1,11 @@
-import { Card, Col, Row, Switch} from "antd";
-import React, { useMemo, useState, useEffect, useRef } from 'react';
+import { Card, Col, Row } from "antd";
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import FeatureSelect from "./FeatureSelect.js";
 import LineChart from './LineChart.js';
 
 const FeatureView = ({ data, timeRange, selectedDims, selectedPoints, setSelectedDims, zScores, setzScores, setBaselines, fcs, baselines, nodeClusterMap }) => {
     const baselinesRef = useRef({});
     const [selectedTimeRange, setSelectedTimeRange] = useState(timeRange);
-    
     const processed = useMemo(() => {
         const proc = {};
         data.data.forEach(row => {
@@ -150,7 +149,6 @@ const FeatureView = ({ data, timeRange, selectedDims, selectedPoints, setSelecte
             </Col>
             {/* Right column: List */}
             <Col span={8}>
-                {/* TODO: move this to sidebar at the app level */}
                 <FeatureSelect 
                     data={data} processed={processed} selectedDims={selectedDims}
                     selectedPoints={selectedPoints} setSelectedDims={setSelectedDims}

--- a/ui/src/components/NodeStatusView.js
+++ b/ui/src/components/NodeStatusView.js
@@ -1,7 +1,7 @@
 import { Card } from "antd";
 import * as d3 from 'd3';
 import React, { useEffect, useRef, useState } from 'react';
-import { generateColor, colorScale } from '../utils/colors.js';
+import { colorScale } from '../utils/colors.js';
 import Tooltip from '../utils/tooltip.js';
 
 const NodeStatusView = ({ nodeData, bStart, bEnd, nodeDataStart, nodeDataEnd, nodeClusterMap }) => {
@@ -358,7 +358,7 @@ const NodeStatusView = ({ nodeData, bStart, bEnd, nodeDataStart, nodeDataEnd, no
           .call(brush.move, defaultWindow)
 
       
-      }, []);
+      }, [nodeClusterMap]);
 
     const updateCharts = (newDomain) => {
         const chart = d3.select(`#focus-line-1`);


### PR DESCRIPTION
# Backend changes
- Cached DR2 result from `get_dr_time()` into a parquet. 
  - This cache is cleared on every server restart so `recompute_clusters()` does not get stale data (see below).
- Added `recompute_clusters()` to `dr_time.py`, which reruns `id_clusters_w_k_means` and `get_feat_contributions` on a the cached DR2 result from `get_dr_time()`.

# Frontend changes
- `<DR>`:
  - Passed in existing `nodeClusterMap` from `App.js` as a new prop. 
  - Color nodes based on `nodeClusterMap` instead of `data => d.Cluster`.
  - Add `useEffect()` that only updates node colors on `nodeClusterMap` change without redrawing entire graph.
  - Changed # cluster input to a `<Select>` dropdown with options from 2-20. 
    - On change, this calls `updateClustersCallback()` in `<App>` which:
      1. Calls new endpoint `/recomputeClusters/<numClusters>`.
      2. Recomputes cluster IDs and feature contributions per cluster.
      3. Updates `nodeClusterMap` and `FCs` state in `App.js`. This rerenders `<NodeStatusView>`, `<FeatureView>`, and `<DR>`.
- `<NodeStatusView>`:
  - Added `nodeClusterMap` as dependency to main render `useEffect()`.
- `<FeatureContributionBarGraph>`
  - Clear SVG on render to prevent duplicate bar graphs when `fcData` updates.

# Preview
![image](https://github.com/user-attachments/assets/dce138d7-926b-4040-8691-16b0b18131f0)
